### PR TITLE
Add github action linters for drupal coding standards

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,23 @@
+name: Linters
+
+on: pull_request
+
+env:
+  GITHUB_BASE_REF: ${{ github.base_ref }}
+
+jobs:
+  run-linters:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install phpcs
+        run: cd bin && ./install-php-linter
+
+      - name: Fetch target branch
+        run: git fetch -n origin ${GITHUB_BASE_REF}
+
+      - name: Run phpcs with Drupal coding standards
+        run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' '*.module' '*.inc' '*.install' '*.theme' ':!*.features.*' | xargs -r ./bin/phpcs.phar --standard=drupal.phpcs.xml

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Download PHPCS if it already does not exist
+if [ ! -f phpcs.phar ]; then
+  curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+fi
+# Give executable permission to PHPCS
+chmod +x phpcs.phar
+
+# Clone Drupal Coder repo
+if [ ! -d drupal/coder ]; then
+  git clone --depth 1 https://git.drupalcode.org/project/coder.git drupal/coder
+fi

--- a/drupal.phpcs.xml
+++ b/drupal.phpcs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="PHPCS Drupal Ruleset">
+  <description>PHP CodeSniffer configuration for Drupal development.</description>
+
+  <arg name="extensions" value="php,module,inc,install,theme"/>
+
+  <config name="drupal_core_version" value="7"/>
+
+  <!-- Drupal sniffs -->
+  <rule ref="bin/drupal/coder/coder_sniffer/Drupal">
+    <exclude name="Drupal.Files.TxtFileLineLength.TooLong"/>
+  </rule>
+</ruleset>


### PR DESCRIPTION
## Overview

This PR adds Github actions workflow for PHP Linters that checks for Drupal coding standards using Coder module when we create new Pull request.

## Before

- Phpcs linter for drupal was not run automatically. 

## After
- Github action will be triggered when Pull Request is created/updated
- Phpcs will check for Drupal coding standards across ssp core modules using PHPCS Drupal ruleset.

## Technical Details

PHP CS linter for Drupal coding standards are implemented using an define Ruleset xml file that defines what Drupal sniffs we need to use. 
With Drupal coding standards sniff we are excluding "Drupal.Files.TxtFileLineLength.TooLong" as default coding standards suggests to use 80 chars line but there are scenarios where we need to have longer line length so ignore sniffs related to this. 

```
<?xml version="1.0" encoding="UTF-8"?>
<ruleset name="PHPCS Drupal Ruleset">
  <description>PHP CodeSniffer configuration for Drupal development.</description>

  <arg name="extensions" value="php,module,inc,install,theme"/>

  <config name="drupal_core_version" value="7"/>

  <!-- Drupal sniffs -->
  <rule ref="Drupal">
    <exclude name="Drupal.Files.TxtFileLineLength.TooLong"/>
  </rule>
</ruleset>
```