### PR TITLE
DRU-168: Add node internal title field module

### DIFF
--- a/node_internal_title_field.features.field_base.inc
+++ b/node_internal_title_field.features.field_base.inc
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * node_internal_title_field.features.field_base.inc
+ */
+
+/**
+ * Implements hook_field_default_field_bases().
+ */
+function node_internal_title_field_field_default_field_bases() {
+  $field_bases = array();
+
+  // Exported field_base: 'field_node_internal_title'.
+  $field_bases['field_node_internal_title'] = array(
+    'active' => 1,
+    'cardinality' => 1,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'field_node_internal_title',
+    'indexes' => array(
+      'format' => array(
+        0 => 'format',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'text',
+    'settings' => array(
+      'max_length' => 255,
+    ),
+    'translatable' => 0,
+    'type' => 'text',
+  );
+
+  return $field_bases;
+}

--- a/node_internal_title_field.features.field_instance.inc
+++ b/node_internal_title_field.features.field_instance.inc
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @file
+ * node_internal_title_field.features.field_instance.inc
+ */
+
+/**
+ * Implements hook_field_default_field_instances().
+ */
+function node_internal_title_field_field_default_field_instances() {
+  $field_instances = array();
+
+  // Exported field_instance: 'node-page-field_node_internal_title'.
+  $field_instances['node-page-field_node_internal_title'] = array(
+    'bundle' => 'page',
+    'default_value' => NULL,
+    'deleted' => 0,
+    'description' => '',
+    'display' => array(
+      'default' => array(
+        'label' => 'hidden',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 1,
+      ),
+      'teaser' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+    ),
+    'entity_type' => 'node',
+    'field_name' => 'field_node_internal_title',
+    'label' => 'Internal Title',
+    'required' => 0,
+    'settings' => array(
+      'text_processing' => 0,
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'active' => 1,
+      'module' => 'text',
+      'settings' => array(
+        'size' => 60,
+      ),
+      'type' => 'text_textfield',
+      'weight' => 33,
+    ),
+  );
+
+  // Exported field_instance: 'node-webform-field_node_internal_title'.
+  $field_instances['node-webform-field_node_internal_title'] = array(
+    'bundle' => 'webform',
+    'default_value' => NULL,
+    'deleted' => 0,
+    'description' => '',
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'module' => 'text',
+        'settings' => array(),
+        'type' => 'text_default',
+        'weight' => 0,
+      ),
+      'teaser' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+    ),
+    'entity_type' => 'node',
+    'field_name' => 'field_node_internal_title',
+    'label' => 'Form Internal Title',
+    'required' => 0,
+    'settings' => array(
+      'text_processing' => 0,
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'active' => 1,
+      'module' => 'text',
+      'settings' => array(
+        'size' => 60,
+      ),
+      'type' => 'text_textfield',
+      'weight' => 31,
+    ),
+  );
+
+  // Translatables
+  // Included for use with string extractors like potx.
+  t('Internal Title');
+  t('Form Internal Title');
+
+  return $field_instances;
+}

--- a/node_internal_title_field.info
+++ b/node_internal_title_field.info
@@ -1,0 +1,11 @@
+name = Node Internal Title Field
+description = Creates "Internal title" field on content types.
+core = 7.x
+package = Compucorp
+version = 7.x-1.0
+dependencies[] = features
+dependencies[] = text
+features[features_api][] = api:2
+features[field_base][] = field_node_internal_title
+features[field_instance][] = node-page-field_node_internal_title
+features[field_instance][] = node-webform-field_node_internal_title

--- a/node_internal_title_field.module
+++ b/node_internal_title_field.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Drupal needs this blank file.
+ */


### PR DESCRIPTION
## Overview

This PR implements Node Internal Title module that creates "Form Internal Title" field on Webform and Basic Page content type only that will help nodes to be easily identify using Internal Title field rather than using Default Title field as title is frequent changed by client and then its difficult for PMs to point to specific webform or page. 

## Before
No "Form Internal Title" field on Webform 
No "Internal Title" field on Basic page

## After
Webform content type- 
![image](https://user-images.githubusercontent.com/2689257/90136906-7b311780-dd92-11ea-9c47-2df7ebfaf355.png)

Basic page content type-
![image](https://user-images.githubusercontent.com/2689257/90136909-7cfadb00-dd92-11ea-8bb5-d6208fe07432.png)

## Technical Details

- Form internal title field is created using features module that creates on Webform and Basic Page content type.