### PR TITLE
FEMS-372: Make field hidden by default

### DIFF
--- a/node_internal_title_field.features.field_instance.inc
+++ b/node_internal_title_field.features.field_instance.inc
@@ -59,10 +59,9 @@ function node_internal_title_field_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'above',
-        'module' => 'text',
         'settings' => array(),
-        'type' => 'text_default',
-        'weight' => 0,
+        'type' => 'hidden',
+        'weight' => 1,
       ),
       'teaser' => array(
         'label' => 'above',


### PR DESCRIPTION
## Overview
This PR makes that the internal title does not get displayed on the form by default.

## Before
The internal title was configured as a visible field:
<img width="1680" alt="Screen Shot 2021-11-09 at 20 39 50" src="https://user-images.githubusercontent.com/74304572/140935350-382b1b61-3565-4cf8-881e-79586c892688.png">
Then it was displayed when visualized:
<img width="1680" alt="Screen Shot 2021-11-09 at 20 42 24" src="https://user-images.githubusercontent.com/74304572/140935449-105f0935-7d49-424d-8069-a28f2adca8a4.png">

## After
The field is on the hidden section:
<img width="1680" alt="Screen Shot 2021-11-09 at 20 37 16" src="https://user-images.githubusercontent.com/74304572/140935524-4acf5883-f339-4759-8078-acc0eb592a37.png">
Then it is not displayed:
<img width="1680" alt="Screen Shot 2021-11-09 at 20 43 03" src="https://user-images.githubusercontent.com/74304572/140935588-c0427bbc-9af3-4c3f-86fa-8ac374f6dd07.png">

## Technical Details
The changes are just the result of moving the field and update the feature.
